### PR TITLE
Breaking change: Corrected dealiasing coefficient.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Advectra"
 uuid = "18c2cdae-170a-11f1-a6b3-2fcf687df0ab"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["JohannesMorkrid <johannes.e.morkrid@uit.no>"]
 
 [deps]

--- a/src/operators/quadraticTerm.jl
+++ b/src/operators/quadraticTerm.jl
@@ -30,7 +30,7 @@ struct QuadraticTerm{TP<:AbstractTransformPlans,P<:AbstractArray,SP<:AbstractArr
         V = similar(U)
 
         # Calculate correct conversion coefficent
-        dealiasing_coefficient = precision(length(up) / spectral_length(domain))
+        dealiasing_coefficient = precision(length(U) / length(domain))
 
         new{typeof(transforms),typeof(U),typeof(up),
             typeof(dealiasing_coefficient)}(transforms, U, V, up, vp,


### PR DESCRIPTION
I thought that the dealiasing coefficent was dependent on if real_transform was used or not, that is not the case as AbstractFFTs.jl scales by the number of grid points in physical and not spectral space