### PR TITLE
Domain refactoring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Advectra"
 uuid = "18c2cdae-170a-11f1-a6b3-2fcf687df0ab"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["JohannesMorkrid <johannes.e.morkrid@uit.no>"]
 
 [deps]

--- a/src/Advectra.jl
+++ b/src/Advectra.jl
@@ -1,7 +1,7 @@
 module Advectra
 
 using FFTW, HDF5, H5Zblosc, LinearAlgebra, LaTeXStrings, MuladdMacro, UnPack, Base.Threads,
-      Dates, GPUArrays, Adapt, Statistics
+    Dates, GPUArrays, Adapt, Statistics
 export @unpack
 
 # TODO make ext
@@ -11,7 +11,8 @@ include("operators/fftutilities.jl")
 export spectral_transform, spectral_transform!, get_fwd, get_bwd
 
 include("domains/domain.jl")
-export Domain, wave_vectors, get_points, spectral_size, spectral_length, get_transform_plans
+export Domain, wave_vectors, get_points, spectral_size, spectral_length, get_transform_plans,
+    array_wrapper, memory_type, allocate, allocate_physical, allocate_spectral, area, evaluate
 
 include("operators/spectralOperators.jl")
 export OperatorRecipe, build_operators, build_operator # TODO perhaps remove and swap with @op
@@ -21,18 +22,17 @@ export OperatorRecipe, build_operators, build_operator # TODO perhaps remove and
 using ProgressMeter, Interpolations
 include("diagnostics/diagnostics.jl")
 export radial_density_profile, poloidal_density_profile, radial_vorticity_profile,
-       poloidal_vorticity_profile, poloidal_vorticity_profile, ProgressDiagnostic,
-       plot_frequencies, @diagnostics, DiagnosticRecipe
+    poloidal_vorticity_profile, poloidal_vorticity_profile, @diagnostics, DiagnosticRecipe
 export cfl, radial_COM, plot_density, plot_vorticity, plot_potential,
-       potential_energy_integral, kinetic_energy_integral, zonal_kinetic_energy_integral,
-       streamer_kinetic_energy_integral, total_energy_integral, enstrophy_energy_integral,
-       flux_magnitude, resistive_dissipation_integral, potential_dissipation_integral,
-       kinetic_dissipation_integral, viscous_dissipation_integral,
-       enstrophy_dissipation_integral, energy_evolution_integral,
-       enstrophy_evolution_integral, radial_flux, poloidal_flux, probe_density,
-       probe_vorticity, probe_potential, probe_radial_velocity, probe_all, progress,
-       get_modes, get_log_modes, potential_energy_spectrum, flux_spectrum,
-       kinetic_energy_spectrum, enstrophy_spectrum, electrostatic_potential_spectrum
+    potential_energy_integral, kinetic_energy_integral, zonal_kinetic_energy_integral,
+    streamer_kinetic_energy_integral, total_energy_integral, enstrophy_energy_integral,
+    flux_magnitude, resistive_dissipation_integral, potential_dissipation_integral,
+    kinetic_dissipation_integral, viscous_dissipation_integral,
+    enstrophy_dissipation_integral, energy_evolution_integral,
+    enstrophy_evolution_integral, radial_flux, poloidal_flux, probe_density,
+    probe_vorticity, probe_potential, probe_radial_velocity, probe_all, progress,
+    get_modes, get_log_modes, potential_energy_spectrum, flux_spectrum,
+    kinetic_energy_spectrum, enstrophy_spectrum, electrostatic_potential_spectrum
 
 include("spectralODEProblem.jl")
 export SpectralODEProblem
@@ -48,9 +48,9 @@ export spectral_solve
 
 include("utilities.jl")
 export initial_condition, @nobroadcast, gaussian, log_gaussian, gaussian_x, gaussian_y,
-       sinusoidal, sinusoidal_x, sinusoidal_y, quadratic_y, exponential_x, white_noise,
-       random_phase, random_crossphased, isolated_blob, isolated_temperature_blob,
-       frequencies, remove_zonal_modes!, remove_streamer_modes!, remove_asymmetric_modes!,
-       remove_nyquist_modes!, remove_nothing!, add_constant!, add_constant, send_mail,
-       logspace, spectral_sum
+    sinusoidal, sinusoidal_x, sinusoidal_y, quadratic_y, exponential_x, white_noise,
+    random_phase, random_crossphased, isolated_blob, isolated_temperature_blob,
+    frequencies, remove_zonal_modes!, remove_streamer_modes!, remove_asymmetric_modes!,
+    remove_nyquist_modes!, remove_nothing!, add_constant!, add_constant, send_mail,
+    logspace, spectral_sum
 end

--- a/src/diagnostics/probe.jl
+++ b/src/diagnostics/probe.jl
@@ -26,7 +26,7 @@ function probe_field(field::AbstractArray, domain::AbstractDomain, position)
 end
 
 function probe_field(field::AbstractInterpolation, domain::AbstractDomain,
-                     position::NTuple{2,Number})
+    position::NTuple{2,Number})
     field(position[2], position[1])
 end
 
@@ -42,8 +42,8 @@ end
   The method is dispatched on the `interpolation` method.
 """
 function probe_field(field::AbstractArray, domain::AbstractDomain,
-                     positions::AbstractArray{<:Tuple},
-                     interpolation::Nothing=nothing)
+    positions::AbstractArray{<:Tuple},
+    interpolation::Nothing=nothing)
     data = [probe_field(field, domain, position) for position in positions]
 
     # Return either the one point, or the array
@@ -54,8 +54,8 @@ end
 
 # Uses pre-computed indices
 function probe_field(field::AbstractArray, domain::AbstractDomain,
-                     indices::AbstractArray{<:Integer},
-                     interpolation::Nothing=nothing)
+    indices::AbstractArray{<:Integer},
+    interpolation::Nothing=nothing)
     data = field[indices]
     # Return either the one point, or the array
     length(data) == 1 ? only(Array(data)) : data
@@ -85,7 +85,7 @@ end
 # --------------------------------- Interpolated Probing -----------------------------------
 
 function probe_field(field::AbstractArray, domain::AbstractDomain, positions::AbstractArray,
-                     interpolation::AbstractInterpolation)
+    interpolation::AbstractInterpolation)
     interpolated = interpolation((domain.y, domain.x), field)
     data = [probe_field(interpolated, domain, position) for position in positions]
     # Return either the one point, or the array
@@ -157,7 +157,7 @@ end
 """
 function prepare_indices(positions, domain::Domain)
     Ind = LinearIndices((size(domain)))
-    [Ind[get_index(position, domain)...] for position in positions] |> domain.MemoryType
+    [Ind[get_index(position, domain)...] for position in positions] |> array_wrapper(domain)
 end
 
 """
@@ -168,12 +168,12 @@ end
 """
 function prepare_metadata(positions::AbstractArray{<:Tuple}, quantities::AbstractArray)
     return string("Probe at positions: ", join(positions, "; "), ", measuring: ",
-                  join(quantities, ", "), ".")
+        join(quantities, ", "), ".")
 end
 
 function prepare_metadata(positions::AbstractArray{<:Tuple}, quantities::String)
     return string("Probe at positions: ", join(positions, "; "), ", measuring: ",
-                  quantities, ".")
+        quantities, ".")
 end
 
 """
@@ -183,7 +183,7 @@ end
   General build method for probe diagnostics which prepares the positions and metadata.
 """
 function build_probe_diagnostic(; name, method, positions, domain, quantities,
-                                assumes_spectral_state=false, interpolation=nothing)
+    assumes_spectral_state=false, interpolation=nothing)
     # Bound and type checking
     positions = prepare_positions(positions, domain)
     # Can pre-compute indices if not using interpolation
@@ -193,11 +193,11 @@ function build_probe_diagnostic(; name, method, positions, domain, quantities,
         args = (positions,)
     end
     Diagnostic(; name=name,
-               method=method,
-               metadata=prepare_metadata(positions, quantities),
-               assumes_spectral_state=assumes_spectral_state,
-               args=args,
-               kwargs=(; interpolation=interpolation,))
+        method=method,
+        metadata=prepare_metadata(positions, quantities),
+        assumes_spectral_state=assumes_spectral_state,
+        args=args,
+        kwargs=(; interpolation=interpolation,))
 end
 
 # ------------------------------------------------------------------------------------------
@@ -217,13 +217,13 @@ function probe_density(state, prob, time, positions; interpolation=nothing)
 end
 
 function build_diagnostic(::Val{:probe_density}; domain, positions,
-                          interpolation=nothing, kwargs...)
+    interpolation=nothing, kwargs...)
     build_probe_diagnostic(; name="Density probe",
-                           method=probe_density,
-                           positions=positions,
-                           domain=domain,
-                           quantities="density",
-                           interpolation=interpolation)
+        method=probe_density,
+        positions=positions,
+        domain=domain,
+        quantities="density",
+        interpolation=interpolation)
 end
 
 # --------------------------------------- Vorticity ----------------------------------------
@@ -239,13 +239,13 @@ function probe_vorticity(state, prob, time, positions; interpolation=nothing)
 end
 
 function build_diagnostic(::Val{:probe_vorticity}; domain, positions,
-                          interpolation=nothing, kwargs...)
+    interpolation=nothing, kwargs...)
     build_probe_diagnostic(; name="Vorticity probe",
-                           method=probe_vorticity,
-                           positions=positions,
-                           domain=domain,
-                           quantities="vorticity",
-                           interpolation=interpolation)
+        method=probe_vorticity,
+        positions=positions,
+        domain=domain,
+        quantities="vorticity",
+        interpolation=interpolation)
 end
 
 # --------------------------------------- Temperature ----------------------------------------
@@ -261,13 +261,13 @@ function probe_temperature(state, prob, time, positions; interpolation=nothing)
 end
 
 function build_diagnostic(::Val{:probe_temperature}; domain, positions,
-                          interpolation=nothing, kwargs...)
+    interpolation=nothing, kwargs...)
     build_probe_diagnostic(; name="Temperature probe",
-                           method=probe_temperature,
-                           positions=positions,
-                           domain=domain,
-                           quantities="temperature",
-                           interpolation=interpolation)
+        method=probe_temperature,
+        positions=positions,
+        domain=domain,
+        quantities="temperature",
+        interpolation=interpolation)
 end
 
 # --------------------------------------- Potential ----------------------------------------
@@ -290,14 +290,14 @@ end
 requires_operator(::Val{:probe_potential}; kwargs...) = [OperatorRecipe(:solve_phi)]
 
 function build_diagnostic(::Val{:probe_potential}; domain, positions,
-                          interpolation=nothing, kwargs...)
+    interpolation=nothing, kwargs...)
     build_probe_diagnostic(; name="Phi probe",
-                           method=probe_potential,
-                           positions=positions,
-                           domain=domain,
-                           quantities="potential",
-                           assumes_spectral_state=true,
-                           interpolation=interpolation)
+        method=probe_potential,
+        positions=positions,
+        domain=domain,
+        quantities="potential",
+        assumes_spectral_state=true,
+        interpolation=interpolation)
 end
 
 # ------------------------------------ Radial Velocity -------------------------------------
@@ -324,14 +324,14 @@ function requires_operator(::Val{:probe_radial_velocity}; kwargs...)
 end
 
 function build_diagnostic(::Val{:probe_radial_velocity}; domain, positions,
-                          interpolation=nothing, kwargs...)
+    interpolation=nothing, kwargs...)
     build_probe_diagnostic(; name="Radial velocity probe",
-                           method=probe_radial_velocity,
-                           positions=positions,
-                           domain=domain,
-                           quantities="radial velocity",
-                           assumes_spectral_state=true,
-                           interpolation=interpolation)
+        method=probe_radial_velocity,
+        positions=positions,
+        domain=domain,
+        quantities="radial velocity",
+        assumes_spectral_state=true,
+        interpolation=interpolation)
 end
 
 # -------------------------------------- All Fields ----------------------------------------
@@ -375,16 +375,16 @@ function requires_operator(::Val{:probe_all}; kwargs...)
 end
 
 function build_diagnostic(::Val{:probe_all}; domain, positions, interpolation=nothing,
-                          kwargs...)
+    kwargs...)
     build_probe_diagnostic(; name="All probe",
-                           method=probe_all,
-                           positions=positions,
-                           domain=domain,
-                           quantities=["density",
-                               "vorticity",
-                               "potential",
-                               "radial velocity",
-                               "radial flux"],
-                           assumes_spectral_state=true,
-                           interpolation=interpolation)
+        method=probe_all,
+        positions=positions,
+        domain=domain,
+        quantities=["density",
+            "vorticity",
+            "potential",
+            "radial velocity",
+            "radial flux"],
+        assumes_spectral_state=true,
+        interpolation=interpolation)
 end

--- a/src/domains/domain.jl
+++ b/src/domains/domain.jl
@@ -1,6 +1,13 @@
 # ------------------------------------- Domain ---------------------------------------------
 
-abstract type AbstractDomain end
+abstract type AbstractDomain{T<:Number} end
+
+"""
+    eltype(::Type{<:AbstractDomain{T}}) where {T}
+
+Return the physical-space element type `T`
+"""
+Base.eltype(::Type{<:AbstractDomain{T}}) where {T} = T
 
 """
 Two dimensional `Domain` assuming bi-spectral boundary conditions, equiped with \
@@ -48,7 +55,7 @@ In addition the `Domain` store info about the [`wave_vectors`]() associated with
 used to configure transform plans. `Array` is used by default but all `<:AbstractArray` \
 types should be supported as long as the corresponding `MemoryType` package is loaded.
 - `precision`: precision `Type` used in numerical calculations, also applies to precision of \
-type and output. Defaults to `Float64`. Should be a numerical `DataType`.
+type and output. Defaults to `Float64`. Must be a numerical `DataType`.
 - `real_transform`: boolean flag to tell the program whether or not to use `rfft` and `irfft` \
 methods to transform between physical and spectral space. This halves the number of spectral \
 coefficient needed to be stored. Defaults to `true`.
@@ -79,35 +86,31 @@ Domain(Nx:128, Ny:256, Lx:1.0, Ly:2.0, real_transform:true, dealiased:true, Memo
 !!! warning
     Restricted to 2D for the time being.
 """
-struct Domain{X<:AbstractArray,Y<:AbstractArray,KX<:AbstractArray,
-              KY<:AbstractArray,TP<:AbstractTransformPlans,
-              T<:AbstractFloat} <: AbstractDomain
+struct Domain{T<:Number,V<:AbstractVector{T},TP<:AbstractTransformPlans} <: AbstractDomain{T}
     Nx::Int
     Ny::Int
     Lx::T
     Ly::T
     dx::T
     dy::T
-    x::X
-    y::Y
-    kx::KX
-    ky::KY
+    x::LinRange{T}
+    y::LinRange{T}
+    kx::V
+    ky::V
     real_transform::Bool
     dealiased::Bool
     transforms::TP
-    MemoryType::Type
-    precision::DataType
 
     Domain(N::Integer; L::Number=1, kwargs...) = Domain(N, N; Lx=L, Ly=L, kwargs...)
     function Domain(Nx::Integer, Ny::Integer;
-                    Lx::Number=1,
-                    Ly::Number=1,
-                    MemoryType::Type{<:AbstractArray}=Array,
-                    precision::DataType=Float64,
-                    real_transform::Bool=true,
-                    dealiased::Bool=true,
-                    x0::Number=-Lx / 2,
-                    y0::Number=-Ly / 2)
+        Lx::Number=1.0,
+        Ly::Number=1.0,
+        MemoryType::Type{<:AbstractArray}=Array,
+        precision::DataType=Float64,
+        real_transform::Bool=true,
+        dealiased::Bool=true,
+        x0::Number=(-Lx / 2),
+        y0::Number=(-Ly / 2))
 
         # Ensure MemoryType is not parameterized
         if MemoryType.var.name != :T
@@ -128,16 +131,15 @@ struct Domain{X<:AbstractArray,Y<:AbstractArray,KX<:AbstractArray,
         x = LinRange{precision}(x0, x0 + Lx - dx, Nx)
         y = LinRange{precision}(y0, y0 + Ly - dy, Ny)
 
-        # Prepare frequencies
+        # Prepare frequencies (kx, ky always share one concrete array type)
         kx, ky = prepare_frequencies(Nx, Ny, dx, dy, MemoryType, precision, real_transform)
 
         # Prepare transform plans
         transform_plans = prepare_transform_plans(Nx, Ny, MemoryType, precision,
-                                                  real_transform)
+            real_transform)
 
-        new{typeof(x),typeof(y),typeof(kx),typeof(ky),typeof(transform_plans),
-            precision}(Nx, Ny, Lx, Ly, dx, dy, x, y, kx, ky, real_transform, dealiased,
-                       transform_plans, MemoryType, precision)
+        new{precision,typeof(kx),typeof(transform_plans)}(Nx, Ny, Lx, Ly, dx, dy, x, y,
+            kx, ky, real_transform, dealiased, transform_plans)
     end
 end
 
@@ -254,7 +256,7 @@ wave_vectors(domain::Domain) = (domain.ky, domain.kx)
 Return the domain specific keyword arguments, depending on the type of AbstractDomain.
 """
 domain_kwargs(domain::Domain) = (; real_transform=domain.real_transform,
-                                 dealiased=domain.dealiased)
+    dealiased=domain.dealiased)
 
 """
     spectral_size(domain::AbstractDomain)
@@ -288,10 +290,98 @@ differential_area(domain::AbstractDomain) = prod(differential_elements(domain))
 get_transform_plans(domain::AbstractDomain) = domain.transforms
 get_fwd(domain::AbstractDomain) = get_fwd(get_transform_plans(domain))
 get_bwd(domain::AbstractDomain) = get_bwd(get_transform_plans(domain))
-get_precision(domain::AbstractDomain) = domain.precision
-memory_type(domain::AbstractDomain) = domain.MemoryType{domain.precision}
+
+get_precision(domain::Domain) = eltype(domain)
+
+"""
+    array_wrapper(::Type{<:AbstractArray})
+    array_wrapper(domain::AbstractDomain)
+
+Return the bare array "MemoryType" (`Array`, `CuArray`, ...) of a concrete array type, \
+or of `domain`'s `kx`/`ky` array type. 
+"""
+array_wrapper(::Type{A}) where {A<:AbstractArray} = Base.typename(A).wrapper
+array_wrapper(domain::AbstractDomain) = array_wrapper(typeof(domain.kx))
+
+"""
+    memory_type(domain::AbstractDomain)
+
+Return the concrete memory type (e.g. `Array{Float64}`, `CuArray{Float32}`) domain's \
+numerical fields live in.
+"""
+memory_type(domain::AbstractDomain) = array_wrapper(domain){eltype(domain)}
 
 # Overloading
 Base.size(domain::AbstractDomain) = (domain.Ny, domain.Nx)
 Base.length(domain::AbstractDomain) = prod(size(domain))
 Base.ndims(domain::AbstractDomain) = length(size(domain))
+
+# ---------------------------------- Allocation Helpers ------------------------------------
+
+"""
+    Representation
+
+Abstract trait describing which space an allocated array lives in: [`Physical`](@ref) or \
+[`Spectral`](@ref). Passed to [`allocate`](@ref) to select eltype and default shape.
+"""
+abstract type Representation end
+struct Physical <: Representation end
+struct Spectral <: Representation end
+
+"""
+    spectral_eltype(domain::AbstractDomain)
+
+Return the spectral-space element type, `Complex{eltype(domain)}`.
+"""
+spectral_eltype(domain::AbstractDomain) = Complex{eltype(domain)}
+
+"""
+    allocate(domain::AbstractDomain, ::Physical, dims::Tuple=size(domain))
+    allocate(domain::AbstractDomain, ::Spectral, dims::Tuple=spectral_size(domain))
+
+Allocate an uninitialized array in the given [`Representation`](@ref) ([`Physical`](@ref) \
+or [`Spectral`](@ref)), using `domain`'s memory type and the appropriate eltype for that \
+space. `dims` defaults to `domain`'s natural shape in that space, but can be overridden — \
+e.g. to stack several fields along a trailing dimension. [`allocate_physical`](@ref) and \
+[`allocate_spectral`](@ref) are the usual entry points; use `allocate` directly when writing \
+code that's generic over `Representation`.
+"""
+allocate(domain::AbstractDomain, ::Physical, dims::Tuple=size(domain)) =
+    array_wrapper(domain){eltype(domain)}(undef, dims)
+allocate(domain::AbstractDomain, ::Spectral, dims::Tuple=spectral_size(domain)) =
+    array_wrapper(domain){spectral_eltype(domain)}(undef, dims)
+
+"""
+    allocate_physical(domain::AbstractDomain; dims::Tuple=size(domain))
+    allocate_physical(domain::AbstractDomain, nfields::Integer)
+
+Allocate an uninitialized physical-space array. With no extra argument, shape is \
+`size(domain)`. Pass `dims` for a custom shape, or an `Integer` to stack `nfields` \
+physical-space fields along a trailing dimension.
+"""
+allocate_physical(domain::AbstractDomain; dims::Tuple=size(domain)) =
+    allocate(domain, Physical(), dims)
+allocate_physical(domain::AbstractDomain, nfields::Integer) =
+    allocate_physical(domain; dims=(size(domain)..., nfields))
+
+"""
+    allocate_spectral(domain::AbstractDomain; dims::Tuple=spectral_size(domain))
+    allocate_spectral(domain::AbstractDomain, nfields::Integer)
+
+Allocate an uninitialized spectral-space array. With no extra argument, shape is \
+`spectral_size(domain)`. Pass `dims` for a custom shape, or an `Integer` to stack \
+`nfields` spectral-space fields along a trailing dimension.
+"""
+allocate_spectral(domain::AbstractDomain; dims::Tuple=spectral_size(domain)) =
+    allocate(domain, Spectral(), dims)
+allocate_spectral(domain::AbstractDomain, nfields::Integer) =
+    allocate_spectral(domain; dims=(spectral_size(domain)..., nfields))
+
+"""
+    evaluate(f, domain::AbstractDomain; kwargs...)
+
+Evaluate `f` over `domain`'s coordinate grid (`f.(domain.x', domain.y; kwargs...)`) and \
+return the result on `domain`'s memory type. 
+"""
+evaluate(f, domain::AbstractDomain; kwargs...) =
+    convert(memory_type(domain), f.(domain.x', domain.y; kwargs...))

--- a/src/operators/poissonBracket.jl
+++ b/src/operators/poissonBracket.jl
@@ -13,10 +13,10 @@ struct PoissonBracket{T<:AbstractArray} <: NonLinearOperator
     qt_right::T
 
     function PoissonBracket(domain::AbstractDomain, diff_x::LinearOperator,
-                            diff_y::LinearOperator, quadratic_term::QuadraticTerm)
+        diff_y::LinearOperator, quadratic_term::QuadraticTerm)
 
         # Allocate
-        tmp = zeros(spectral_size(domain)) |> domain.MemoryType{complex(domain.precision)}
+        tmp = fill!(allocate_spectral(domain), zero(spectral_eltype(domain)))
         qt_left = zero(tmp)
         qt_right = zero(qt_left)
 
@@ -29,7 +29,7 @@ function operator_dependencies(::Val{:poisson_bracket}, ::Type{_}) where {_}
 end
 
 function build_operator(::Val{:poisson_bracket}, domain::Domain; diff_x, diff_y,
-                        quadratic_term, kwargs...)
+    quadratic_term, kwargs...)
     PoissonBracket(domain, diff_x, diff_y, quadratic_term)
 end
 

--- a/src/operators/solvePhi.jl
+++ b/src/operators/solvePhi.jl
@@ -18,7 +18,7 @@ end
 
 # 2) Non-Boussinesq, no relaxation:
 struct SolvePhiNonBoussinesq{density,T<:AbstractArray,
-                             S<:AbstractArray,P<:AbstractArray} <: SolvePhi
+    S<:AbstractArray,P<:AbstractArray} <: SolvePhi
     laplacian_inv::T
     diff_x::LinearOperator
     diff_y::LinearOperator
@@ -34,27 +34,27 @@ struct SolvePhiNonBoussinesq{density,T<:AbstractArray,
     maxiters::Number
 
     function SolvePhiNonBoussinesq(domain, diff_x, diff_y, quadratic_term;
-                                   atol, rtol, maxiters, density::Symbol=:log)
+        atol, rtol, maxiters, density::Symbol=:log)
         laplacian = get_laplacian(domain)
         laplacian_inv = laplacian .^ -1
         @allowscalar laplacian_inv[1] = 0 # First entry will always be NaN or Inf
 
-        C1 = zeros(spectral_size(domain)) |> domain.MemoryType{complex(domain.precision)}
+        C1 = fill!(allocate_spectral(domain), zero(spectral_eltype(domain)))
         C2 = zero(C1)
         phi = zero(C1)
         N = zero(quadratic_term.U)
         dηdx = zero(N)
         dηdy = zero(N)
         new{density,typeof(laplacian_inv),typeof(C1),typeof(N)}(laplacian_inv, diff_x,
-                                                                diff_y, quadratic_term, phi,
-                                                                C1, C2, N, dηdx, dηdy, atol,
-                                                                rtol, maxiters)
+            diff_y, quadratic_term, phi,
+            C1, C2, N, dηdx, dηdy, atol,
+            rtol, maxiters)
     end
 end
 
 # 3) Non-Boussinesq, with relaxation:
 struct SolvePhiRelaxation{density,T<:AbstractArray,
-                          S<:AbstractArray,P<:AbstractArray} <: SolvePhi
+    S<:AbstractArray,P<:AbstractArray} <: SolvePhi
     laplacian_inv::T
     diff_x::LinearOperator
     diff_y::LinearOperator
@@ -72,12 +72,12 @@ struct SolvePhiRelaxation{density,T<:AbstractArray,
     w::Number
 
     function SolvePhiRelaxation(domain, diff_x, diff_y, quadratic_term; w,
-                                atol, rtol, maxiters, density::Symbol=:log)
+        atol, rtol, maxiters, density::Symbol=:log)
         laplacian = get_laplacian(domain)
         laplacian_inv = laplacian .^ -1
         @allowscalar laplacian_inv[1] = 0 # First entry will always be NaN or Inf
 
-        C1 = zeros(spectral_size(domain)) |> domain.MemoryType{complex(domain.precision)}
+        C1 = fill!(allocate_spectral(domain), zero(spectral_eltype(domain)))
         C2 = zero(C1)
         initial_phi = zero(C1)
         previous_phi = zero(C1)
@@ -85,10 +85,10 @@ struct SolvePhiRelaxation{density,T<:AbstractArray,
         dηdx = zero(N)
         dηdy = zero(N)
         new{density,typeof(laplacian_inv),typeof(C1),typeof(N)}(laplacian_inv, diff_x,
-                                                                diff_y, quadratic_term,
-                                                                initial_phi, previous_phi,
-                                                                C1, C2, N, dηdx, dηdy, atol,
-                                                                rtol, maxiters, w)
+            diff_y, quadratic_term,
+            initial_phi, previous_phi,
+            C1, C2, N, dηdx, dηdy, atol,
+            rtol, maxiters, w)
     end
 end
 
@@ -101,30 +101,30 @@ end
 
 # General user-interface:
 function build_operator(::Val{:solve_phi}, domain::AbstractDomain; boussinesq=true,
-                        relaxation=false, kwargs...)
+    relaxation=false, kwargs...)
     _build_operator(Val(:solve_phi), domain, Val(boussinesq), Val(relaxation); kwargs...)
 end
 
 # Construct simplified case
 function _build_operator(::Val{:solve_phi}, domain::Domain, boussinesq::Val{true},
-                         relaxation; kwargs...)
+    relaxation; kwargs...)
     SolvePhiSimplified(domain)
 end
 
 # Construct non-bousinesq, no-relaxation case:
 function _build_operator(::Val{:solve_phi}, domain::Domain, boussinesq::Val{false},
-                         relaxation::Val{false}; diff_x, diff_y, quadratic_term, atol=1e-3,
-                         rtol=1e-6, maxiters=100, density=:log, kwargs...)
+    relaxation::Val{false}; diff_x, diff_y, quadratic_term, atol=1e-3,
+    rtol=1e-6, maxiters=100, density=:log, kwargs...)
     SolvePhiNonBoussinesq(domain, diff_x, diff_y, quadratic_term;
-                          atol, rtol, maxiters, density)
+        atol, rtol, maxiters, density)
 end
 
 # Construct non-bousinesq, relaxation case:
 function _build_operator(::Val{:solve_phi}, domain::Domain, boussinesq::Val{false},
-                         relaxation::Val{true}; diff_x, diff_y, quadratic_term, w=0.9,
-                         atol=1e-3, rtol=1e-6, maxiters=100, density=:log, kwargs...)
+    relaxation::Val{true}; diff_x, diff_y, quadratic_term, w=0.9,
+    atol=1e-3, rtol=1e-6, maxiters=100, density=:log, kwargs...)
     SolvePhiRelaxation(domain, diff_x, diff_y, quadratic_term;
-                       w, atol, rtol, maxiters, density)
+        w, atol, rtol, maxiters, density)
 end
 
 # ------------------------------------- Main Methods ---------------------------------------
@@ -142,7 +142,7 @@ end
 
 # In-place (non-boussinesq)
 function (op::SolvePhiNonBoussinesq{:linear})(out::AbstractArray, n::AbstractArray,
-                                              ϖ::AbstractArray)
+    ϖ::AbstractArray)
     @unpack laplacian_inv, diff_x, diff_y, quadratic_term, C1, C2, phi, N, dηdx, dηdy = op
     @unpack atol, rtol, maxiters = op
     @unpack U, V, up, vp, padded, transforms, dealiasing_coefficient = quadratic_term
@@ -228,7 +228,7 @@ function (op::SolvePhiNonBoussinesq{:linear})(out::AbstractArray, n::AbstractArr
 end
 
 function (op::SolvePhiNonBoussinesq{:log})(out::AbstractArray, η::AbstractArray,
-                                           ϖ::AbstractArray)
+    ϖ::AbstractArray)
     @unpack laplacian_inv, diff_x, diff_y, quadratic_term, C1, C2, phi, N, dηdx, dηdy = op
     @unpack atol, rtol, maxiters = op
     @unpack U, V, up, vp, padded, transforms, dealiasing_coefficient = quadratic_term
@@ -319,7 +319,7 @@ end
 
 # In-place (non-boussinesq, relaxation)
 function (op::SolvePhiRelaxation{:linear})(out::AbstractArray, n::AbstractArray,
-                                           ϖ::AbstractArray)
+    ϖ::AbstractArray)
     @unpack laplacian_inv, diff_x, diff_y, quadratic_term, C1, C2, N, dηdx, dηdy = op
     @unpack initial_phi, previous_phi, w, atol, rtol, maxiters = op
     @unpack U, V, up, vp, padded, transforms, dealiasing_coefficient = quadratic_term
@@ -410,7 +410,7 @@ function (op::SolvePhiRelaxation{:linear})(out::AbstractArray, n::AbstractArray,
 end
 
 function (op::SolvePhiRelaxation{:log})(out::AbstractArray, η::AbstractArray,
-                                        ϖ::AbstractArray)
+    ϖ::AbstractArray)
     @unpack laplacian_inv, diff_x, diff_y, quadratic_term, C1, C2, N, dηdx, dηdy = op
     @unpack initial_phi, previous_phi, w, atol, rtol, maxiters = op
     @unpack U, V, up, vp, padded, transforms, dealiasing_coefficient = quadratic_term

--- a/src/operators/spatialDerivatives.jl
+++ b/src/operators/spatialDerivatives.jl
@@ -68,8 +68,8 @@ struct GradDotGradOperator{T<:AbstractArray} <: NonLinearOperator
     right::T
     tmp::T
     function GradDotGradOperator(domain::AbstractDomain, diff_x::LinearOperator,
-                                 diff_y::LinearOperator, quadratic_term::QuadraticTerm)
-        tmp = zeros(spectral_size(domain)) |> domain.MemoryType{complex(domain.precision)}
+        diff_y::LinearOperator, quadratic_term::QuadraticTerm)
+        tmp = fill!(allocate_spectral(domain), zero(spectral_eltype(domain)))
         left = zero(tmp)
         right = zero(tmp)
         new{typeof(tmp)}(diff_x, diff_y, quadratic_term, left, right, tmp)
@@ -81,7 +81,7 @@ function operator_dependencies(::Val{:grad_dot_grad}, ::Type{_}) where {_}
 end
 
 function build_operator(::Val{:grad_dot_grad}, domain::Domain; diff_x, diff_y,
-                        quadratic_term, kwargs...)
+    quadratic_term, kwargs...)
     GradDotGradOperator(domain, diff_x, diff_y, quadratic_term)
 end
 

--- a/src/spectralODEProblem.jl
+++ b/src/spectralODEProblem.jl
@@ -23,11 +23,11 @@ abstract type AbstractODEProblem{isinplace} end
    `kwargs` can be stored in the struct, however these are currently unused.
 """
 mutable struct SpectralODEProblem{LType<:Function,NType<:Function,
-                                  u0Type<:AbstractArray,u0_hatType<:AbstractArray,
-                                  D<:AbstractDomain,tType,pType,
-                                  operatorsType<:NamedTuple,
-                                  diagnosticRecipesType<:Vector,N<:Number,
-                                  RMType<:Function,K,iip} <: AbstractODEProblem{iip}
+    u0Type<:AbstractArray,u0_hatType<:AbstractArray,
+    D<:AbstractDomain,tType,pType,
+    operatorsType<:NamedTuple,
+    diagnosticRecipesType<:Vector,N<:Number,
+    RMType<:Function,K,iip} <: AbstractODEProblem{iip}
     L::LType
     N::NType
     u0::u0Type
@@ -43,26 +43,26 @@ mutable struct SpectralODEProblem{LType<:Function,NType<:Function,
     kwargs::K
 
     function SpectralODEProblem(NonLinear::Function, u0, domain::AbstractDomain, tspan;
-                                p=NullParameters(), dt=0.01,
-                                remove_modes::Function=remove_nothing!, kwargs...)
+        p=NullParameters(), dt=0.01,
+        remove_modes::Function=remove_nothing!, kwargs...)
 
         # If no linear operator given, assume there is non and match signature
         isinplace(NonLinear) isa Val{true} ? L(du, u, operators, p, t) = (du .= zero(u)) :
         L(u, operators, p, t) = zero(u)
 
         SpectralODEProblem(L, NonLinear, u0, domain, tspan; p=p, dt=dt,
-                           remove_modes=remove_modes, kwargs...)
+            remove_modes=remove_modes, kwargs...)
     end
 
     function SpectralODEProblem(Linear::Function, NonLinear::Function, u0,
-                                domain::AbstractDomain, tspan;
-                                p=NullParameters(), dt::Number=0.01,
-                                operators::Symbol=:default,
-                                aliases::Vector{Pair{Symbol,Symbol}}=Pair{Symbol,Symbol}[],
-                                additional_operators::Vector{<:OperatorRecipe}=OperatorRecipe[],
-                                remove_modes::Function=remove_nothing!,
-                                diagnostics::Vector{<:DiagnosticRecipe}=DiagnosticRecipe[],
-                                kwargs...)
+        domain::AbstractDomain, tspan;
+        p=NullParameters(), dt::Number=0.01,
+        operators::Symbol=:default,
+        aliases::Vector{Pair{Symbol,Symbol}}=Pair{Symbol,Symbol}[],
+        additional_operators::Vector{<:OperatorRecipe}=OperatorRecipe[],
+        remove_modes::Function=remove_nothing!,
+        diagnostics::Vector{<:DiagnosticRecipe}=DiagnosticRecipe[],
+        kwargs...)
 
         # Prepare data structures
         u0 = prepare_initial_condition(u0, domain)
@@ -73,15 +73,15 @@ mutable struct SpectralODEProblem{LType<:Function,NType<:Function,
 
         # Handle time related things
         length(tspan) != 2 ? throw("tspan should have exactly two elements") : nothing
-        tspan = convert.(domain.precision, promote(first(tspan), last(tspan)))
-        dt = convert(domain.precision, dt)
+        tspan = convert.(eltype(domain), promote(first(tspan), last(tspan)))
+        dt = convert(eltype(domain), dt)
 
         # Convert parameters to domain precision
         p = convert_parameters(get_precision(domain), p)
 
         # Returns a NamedTuple with `SpectralOperator`s
         ops = build_operators(domain; operators, aliases, additional_operators, diagnostics,
-                              kwargs...)
+            kwargs...)
 
         # Makes the rhs follow the signature used by SciML
         L, N = prepare_functions(Linear, NonLinear, ops)
@@ -89,8 +89,8 @@ mutable struct SpectralODEProblem{LType<:Function,NType<:Function,
         new{typeof(L),typeof(N),typeof(u0),typeof(u0_hat),typeof(domain),typeof(tspan),
             typeof(p),typeof(ops),typeof(diagnostics),typeof(dt),typeof(remove_modes),
             typeof(kwargs),isinplace(Linear, NonLinear)}(L, N, u0, u0_hat, domain, tspan, p,
-                                                         ops, diagnostics, dt, remove_modes,
-                                                         kwargs)
+            ops, diagnostics, dt, remove_modes,
+            kwargs)
     end
 end
 
@@ -111,10 +111,7 @@ end
 
 """
 """
-function prepare_initial_condition(u0, domain::Domain)
-    # Transform to the correct MemoryType for physical space
-    u0 |> domain.MemoryType{eltype(fwd(domain))}
-end
+prepare_initial_condition(u0, domain::Domain) = u0 |> memory_type(domain)
 
 # -------------------------- Spectral Coefficient Initialization ---------------------------
 
@@ -143,7 +140,7 @@ function _allocate_coefficients(u0::AbstractArray{<:Number}, domain::Domain)
     # Allocate array for spectral modes 
     sz = size(get_bwd(domain))
     allocation_size = (sz..., size(u0)[(length(sz)+1):end]...)
-    return zeros(eltype(get_bwd(domain)), allocation_size) |> domain.MemoryType
+    return fill!(allocate_spectral(domain; dims=allocation_size), zero(spectral_eltype(domain)))
 end
 
 function _allocate_coefficients(u0::AbstractArray{<:AbstractArray}, domain::Domain)
@@ -171,8 +168,8 @@ convert_parameters(::Type{T}, x) where {T} = x
   `required_operators` by the `diagnostics` to it.
 """
 function prepare_operator_recipes(operators::Symbol,
-                                  additional_operators::Vector{<:OperatorRecipe},
-                                  diagnostics::Vector{<:DiagnosticRecipe})
+    additional_operators::Vector{<:OperatorRecipe},
+    diagnostics::Vector{<:DiagnosticRecipe})
     # Determine operators trough switches
     recipes = get_operator_recipes(operators)
     # Determine which operators are required by the diagnostics
@@ -214,10 +211,10 @@ function add_aliases!(operators, aliases, cache)
 end
 
 function build_operators(domain::AbstractDomain; operators::Symbol=:default,
-                         aliases::Vector{Pair{Symbol,Symbol}}=Pair{Symbol,Symbol}[],
-                         additional_operators::Vector{<:OperatorRecipe}=OperatorRecipe[],
-                         diagnostics::Vector{<:DiagnosticRecipe}=DiagnosticRecipe[],
-                         problem_kwargs...)
+    aliases::Vector{Pair{Symbol,Symbol}}=Pair{Symbol,Symbol}[],
+    additional_operators::Vector{<:OperatorRecipe}=OperatorRecipe[],
+    diagnostics::Vector{<:DiagnosticRecipe}=DiagnosticRecipe[],
+    problem_kwargs...)
     # Collects all recipes needed to be built
     recipes = prepare_operator_recipes(operators, additional_operators, diagnostics)
 
@@ -226,8 +223,8 @@ function build_operators(domain::AbstractDomain; operators::Symbol=:default,
 
     # Construct NamedTuple
     spectral_operators = (;
-                          [recipe.alias => ensure!(cache, recipe, domain, problem_kwargs)
-                           for recipe in recipes]...)
+        [recipe.alias => ensure!(cache, recipe, domain, problem_kwargs)
+         for recipe in recipes]...)
 
     # Sort out aliases
     spectral_operators = add_aliases!(spectral_operators, aliases, cache)
@@ -239,7 +236,7 @@ end
 
 spectral_size(prob::SpectralODEProblem) = size(prob.u0_hat)
 
-get_precision(prob::SpectralODEProblem) = prob.domain.precision
+get_precision(prob::SpectralODEProblem) = get_precision(prob.domain)
 get_fwd(prob::SpectralODEProblem) = get_fwd(prob.domain)
 get_bwd(prob::SpectralODEProblem) = get_bwd(prob.domain)
 
@@ -293,7 +290,7 @@ get_nonlinear_operator(prob::SpectralODEProblem) = prob.N.NonLinear
 
 function Base.show(io::IO, m::MIME"text/plain", prob::SpectralODEProblem)
     print(io, nameof(typeof(prob)), "(", nameof(prob.L), ",", nameof(prob.N), ";dt=",
-          prob.dt)
+        prob.dt)
     typeof(prob.p) == NullParameters ? nothing : print(io, ",p=", prob.p)
     println(io, "):")
     println(io, "in-place: ", isinplace(prob) isa Val{true})

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -215,9 +215,9 @@ Generate random noise from randomly phased spectral modes, with zonal and stream
 - `ndims`: Number of fields (default `1`)
 """
 @nobroadcast function random_phase(domain::AbstractDomain; value=10^-6, ndims=1,
-                                   include_zonal=false, include_streamer=false)
+    include_zonal=false, include_streamer=false)
     θ = 2π * rand(spectral_size(domain)..., (ndims == 1 ? () : (ndims,))...)
-    u_hat = value .* exp.(im * θ) |> domain.MemoryType
+    u_hat = value .* exp.(im * θ) |> array_wrapper(domain)
     include_zonal || (selectdim(u_hat, 1, 1) .= 0.0)
     include_streamer || (selectdim(u_hat, 2, 1) .= 0.0)
     spectral_transform(u_hat, bwd(domain))
@@ -243,8 +243,8 @@ and the vorticity is derived from the potential via:
 - `cross_phase`: Phase offset between ϕₖ and nₖ modes (default `π/2`)
 """
 @nobroadcast function random_crossphased(domain::AbstractDomain; include_streamer=false,
-                                         include_zonal=false, value=1e-6, cross_phase=π / 2)
-    θ = 2π * rand(spectral_size(domain)...) |> domain.MemoryType
+    include_zonal=false, value=1e-6, cross_phase=π / 2)
+    θ = 2π * rand(spectral_size(domain)...) |> array_wrapper(domain)
     ϕ_hat = value .* exp.(im * θ)
     n_hat = ϕ_hat .* exp(im * cross_phase)
     laplacian = build_operator(:laplacian, domain)
@@ -304,7 +304,7 @@ logarithmic scale. Additional keyword arguments are passed to the underlying
 - `kwargs...`: Passed to [`gaussian`](@ref) or [`log_gaussian`](@ref), typically `A`, `B`, `l`
 """
 @nobroadcast function isolated_temperature_blob(domain::AbstractDomain; ndims=3,
-                                                density::Symbol=:lin, kwargs...)
+    density::Symbol=:lin, kwargs...)
     isolated_temperature_blob(domain, Val(density); ndims, kwargs...)
 end
 

--- a/test/domain_tests.jl
+++ b/test/domain_tests.jl
@@ -1,8 +1,8 @@
 using Test
 using Advectra
 import Advectra: Domain, lengths, wave_vectors, differential_elements,
-                 domain_kwargs, spectral_size, spectral_length, area, differential_area,
-                 get_points
+    domain_kwargs, spectral_size, spectral_length, area, differential_area,
+    get_points
 
 d1 = Domain(256, 256; Lx=1, Ly=1)
 d2 = Domain(256; L=1)
@@ -39,7 +39,7 @@ end
 
 @testset "Wave vectors" for a_domain in Domain_set
     # indices from -Nx/2 .. Nx/2-1 as integers
-    i = vcat(collect(0:(a_domain.Nx÷2-1)), collect(-a_domain.Nx÷2:-1))
+    i = vcat(collect(0:(a_domain.Nx÷2-1)), collect((-a_domain.Nx÷2):-1))
     kx = (2 * π / a_domain.Lx) .* i
     @test wave_vectors(a_domain)[2] ≈ kx
 
@@ -47,7 +47,7 @@ end
         ky_real = (2 * π / a_domain.Ly) .* collect(0:(a_domain.Ny÷2))
         @test wave_vectors(a_domain)[1] ≈ ky_real
     else
-        j = vcat(collect(0:(a_domain.Ny÷2-1)), collect(-a_domain.Ny÷2:-1))
+        j = vcat(collect(0:(a_domain.Ny÷2-1)), collect((-a_domain.Ny÷2):-1))
         ky = (2 * π / a_domain.Ly) .* j
         # to specify tolerances for floating point comparisons
         @test isapprox(wave_vectors(a_domain)[1], ky; rtol=1e-12, atol=1e-12)
@@ -96,25 +96,25 @@ end
 @testset "FFT Round Trip" for a_domain in Domain_set
     # Create a random physical field on the correct memory type
     T = Advectra.get_precision(a_domain)
-    phys_in = rand(T, size(a_domain)...) |> a_domain.MemoryType
-    
+    phys_in = rand(T, size(a_domain)...) |> array_wrapper(d)
+
     fwd = Advectra.get_fwd(a_domain)
     bwd = Advectra.get_bwd(a_domain)
-    
+
     # Physical -> Spectral -> Physical
     spec = fwd * phys_in
     phys_out = bwd * spec
-    
+
     @test Array(phys_in) ≈ Array(phys_out)
 end
 
 @testset "Constructor Failures" begin
     # Test incorrect MemoryType (passing a parameterized type)
     @test_throws ArgumentError Domain(64; MemoryType=Array{Float64})
-    
+
     # Test incorrect precision
     @test_throws ArgumentError Domain(64; precision=String)
-    
+
     # Test non-positive dimensions
     @test_throws ArgumentError Domain(-64; L=1.0)
 end
@@ -123,21 +123,21 @@ end
     for T in [Float32, Float64]
         for real_tr in [true, false]
             d = Domain(32; precision=T, real_transform=real_tr)
-            
+
             @test eltype(d.x) === T
             @test eltype(d.kx) === T
-            
+
             fwd = Advectra.get_fwd(d)
-            
+
             # If it's a real transform, plan expects T (Float)
             # If it's a complex transform, plan expects Complex{T}
             expected_plan_eltype = real_tr ? T : Complex{T}
             @test eltype(fwd) === expected_plan_eltype
-            
+
             # The result of a forward transform is ALWAYS complex
             # Note: for complex transforms, the input must be complex
             input_type = real_tr ? T : Complex{T}
-            phys_tmp = zeros(input_type, size(d)...) |> d.MemoryType
+            phys_tmp = zeros(input_type, size(d)...) |> array_wrapper(d)
             spec_tmp = fwd * phys_tmp
             @test eltype(spec_tmp) === Complex{T}
         end
@@ -149,7 +149,7 @@ end
     Lx, Ly = 2.0, 2.0
     Nx, Ny = 10, 10
     d = Domain(Nx, Ny; Lx=Lx, Ly=Ly, x0=x0, y0=y0)
-    
+
     @test first(d.x) ≈ x0
     @test first(d.y) ≈ y0
     @test last(d.x) ≈ (x0 + Lx - d.dx)
@@ -158,7 +158,7 @@ end
 @testset "IO and Show" begin
     d = Domain(32)
     @test_nowarn show(devnull, MIME"text/plain"(), d)
-    
+
     # Test compact mode used in arrays
     @test_nowarn show(IOContext(devnull, :compact => true), d)
 end

--- a/test/domain_tests.jl
+++ b/test/domain_tests.jl
@@ -96,7 +96,7 @@ end
 @testset "FFT Round Trip" for a_domain in Domain_set
     # Create a random physical field on the correct memory type
     T = Advectra.get_precision(a_domain)
-    phys_in = rand(T, size(a_domain)...) |> array_wrapper(d)
+    phys_in = rand(T, size(a_domain)...) |> array_wrapper(a_domain)
 
     fwd = Advectra.get_fwd(a_domain)
     bwd = Advectra.get_bwd(a_domain)

--- a/test/operator_tests.jl
+++ b/test/operator_tests.jl
@@ -5,8 +5,8 @@ using LinearAlgebra
 # ------------------------------------------------------------------------------
 # 1. Setup Self-Contained Domain Set
 # ------------------------------------------------------------------------------
-d1 = Domain(64, 64; Lx=2π, Ly=2π, real_transform=true,  dealiased=true)
-d2 = Domain(64; L=10.0,          real_transform=false, dealiased=false)
+d1 = Domain(64, 64; Lx=2π, Ly=2π, real_transform=true, dealiased=true)
+d2 = Domain(64; L=10.0, real_transform=false, dealiased=false)
 d3 = Domain(128, 64; Lx=1.0, Ly=2.0, real_transform=true, dealiased=true)
 
 Domain_set = [d1, d2, d3]
@@ -20,19 +20,19 @@ Domain_set = [d1, d2, d3]
     @testset "First Derivatives (Accuracy) - Domain: $(size(d))" for d in Domain_set
         T = Advectra.get_precision(d)
         fwd, bwd = Advectra.get_fwd(d), Advectra.get_bwd(d)
-        
+
         m, n = 2, 3
         k0x = 2π / d.Lx
         k0y = 2π / d.Ly
-        
+
         u_phys = @. sin(m * k0x * d.x') * cos(n * k0y * d.y)
-        u_spec = fwd * (u_phys |> d.MemoryType)
-        
+        u_spec = fwd * (u_phys |> array_wrapper(d))
+
         # --- Test ∂x ---
         dx_op = build_operator(Val(:diff_x), d)
         du_spec = dx_op(u_spec)
         du_phys = Array(bwd * du_spec)
-        
+
         expected_dx = @. (m * k0x) * cos(m * k0x * d.x') * cos(n * k0y * d.y)
         @test isapprox(du_phys, expected_dx; atol=1e-5)
 
@@ -40,7 +40,7 @@ Domain_set = [d1, d2, d3]
         dy_op = build_operator(Val(:diff_y), d)
         dv_spec = dy_op(u_spec)
         dv_phys = Array(bwd * dv_spec)
-        
+
         expected_dy = @. -(n * k0y) * sin(m * k0x * d.x') * sin(n * k0y * d.y)
         @test isapprox(dv_phys, expected_dy; atol=1e-5)
     end
@@ -49,10 +49,10 @@ Domain_set = [d1, d2, d3]
         L_op = build_operator(Val(:laplacian), d)
         Dxx_op = build_operator(Val(:diff_xx), d)
         Dyy_op = build_operator(Val(:diff_yy), d)
-        
+
         # Verify ∇² = ∂xx + ∂yy using the .coeffs field
         @test L_op.coeffs ≈ (Dxx_op.coeffs .+ Dyy_op.coeffs)
-        
+
         @test all(real.(L_op.coeffs) .<= 0)
         @test all(isapprox.(imag.(L_op.coeffs), 0.0; atol=1e-12))
     end
@@ -63,19 +63,19 @@ Domain_set = [d1, d2, d3]
 
         diff_x = build_operator(Val(:diff_x), d)
         diff_y = build_operator(Val(:diff_y), d)
-        
+
         # Wrap in try-catch in case QuadraticTerm isn't fully implemented yet
         try
             q_term = build_operator(Val(:quadratic_term), d)
-            gdg = build_operator(Val(:grad_dot_grad), d; 
-                                 diff_x=diff_x, diff_y=diff_y, quadratic_term=q_term)
+            gdg = build_operator(Val(:grad_dot_grad), d;
+                diff_x=diff_x, diff_y=diff_y, quadratic_term=q_term)
 
             # Test with simple smooth fields
             u_phys = @. cos(2π * d.x' / d.Lx) + 0*d.y
-            v_phys = @. sin(2π * d.y / d.Ly)  + 0*d.x'
-            
-            u_spec = fwd * (u_phys |> d.MemoryType)
-            v_spec = fwd * (v_phys |> d.MemoryType)
+            v_phys = @. sin(2π * d.y / d.Ly) + 0*d.x'
+
+            u_spec = fwd * (u_phys |> array_wrapper(d))
+            v_spec = fwd * (v_phys |> array_wrapper(d))
 
             # Check if calling the operator works
             res_spec = gdg(u_spec, v_spec)
@@ -83,7 +83,7 @@ Domain_set = [d1, d2, d3]
 
             # For these orthogonal inputs, the dot product should be zero
             @test all(isapprox.(res_phys, 0.0; atol=1e-10))
-            
+
         catch e
             if e isa MethodError || e isa UndefVarError
                 @warn "Skipping GradDotGrad: QuadraticTerm dependency not met."


### PR DESCRIPTION
Major breaking change to the Domain struct, removed the precision and MemoryType atributes and instead made them part of the Domain Parameterization which was cleaned up quite a bit. In addition allocation methods such as allocate_physical, allocate_spectral and allocate was added to make allocating the right Array with the correct eltype on the right host more trivial. The additional Representation type may also help improve the interface in the future.